### PR TITLE
Fix api error message

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -40,7 +40,7 @@ var ErrDuplicateID = errors.New("the document you are trying to index has an id 
 
 // APIError is an error returned from the API.
 type APIError struct {
-	Message string `json:"string"`
+	Message string `json:"message"`
 }
 
 // Error returns a string representation of the error.


### PR DESCRIPTION
The field for the APIError is keyed on "message"
json template tags are not supposed to be the type but are actually the name of the field to be serialized 